### PR TITLE
Make trace logging at the debug level

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ function plugin (fastify, options = { enabled: true, tracer: null }, next) {
     }
 
     if (rootSpan) {
-      req.log.info(`New trace<${rootSpan.context().traceId}> was created`)
+      req.log.debug({traceId: rootSpan.context().traceId}, "New trace created")
       rootSpan.end()
       req.opentelemetry.rootSpan = null
     }


### PR DESCRIPTION
Fastify does it's request / reply logging at the `INFO` level, so if one wants request logs in production, they have to run at INFO. I think this means that this library should do its logging at the `DEBUG` level to keep log volume down and the logs easier to read through for humans. This also switches the debug log statement to use Pino's object bindings for the dynamic values which prevents time spent on cobbling together strings for often-unused debug log entries.